### PR TITLE
fork MLX90641_IR_Array and use git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/MLX90641_IR_Array"]
+	path = lib/MLX90641_IR_Array
+	url = git@github.com:EmilePapillon/MLX90641_IR_Array.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,5 +13,3 @@ platform = nordicnrf52
 board = adafruit_feather_nrf52832
 framework = arduino
 monitor_speed = 115200
-lib_deps = 
-    https://github.com/BlackSparkk/MLX90641_IR_Array.git


### PR DESCRIPTION
Instead of relying on a dependency configured via platformio.ini, I forked the repository and adde the dep as a git submodule. This allows us to make modifications to the library like changing the buffersize from 128->32